### PR TITLE
Add initial ast-grep GitHub Actions workflow

### DIFF
--- a/.github/workflows/ast-grep.yml
+++ b/.github/workflows/ast-grep.yml
@@ -1,0 +1,31 @@
+name: Check and test ast-grep rules
+
+'on':
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '12 3 * * 5'
+
+env:
+  AST_GREP_VERSION: "0.38.5"
+
+jobs:
+  conftest:
+    name: Check and test ast-grep rules
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install ast-grep
+        run: |
+          mkdir -p "${HOME}/.local/bin"
+          curl -o "/tmp/ast-grep-${AST_GREP_VERSION}.zip" -sL "https://github.com/ast-grep/ast-grep/releases/download/${AST_GREP_VERSION}/app-x86_64-unknown-linux-gnu.zip"
+          unzip -d "${HOME}/.local/bin" "/tmp/ast-grep-${AST_GREP_VERSION}.zip"
+      - name: Lint YAML files
+        run: |
+          make lint
+      - name: Test ast-grep rules
+        run: |
+          make test


### PR DESCRIPTION
Fetch ast-grep and run `lint` and `test` target in order to check YAML via yamllint and then test actual ast-grep rules.
